### PR TITLE
More styling: A couple modals. Multiline team lists.

### DIFF
--- a/src/components/Main/Teams/DroppableTeamMemberList.tsx
+++ b/src/components/Main/Teams/DroppableTeamMemberList.tsx
@@ -127,6 +127,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     width: '79%',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, 20ch)',
   },
   droppableArea: {
     background: 'lightblue',

--- a/src/components/Main/Teams/TeamList.tsx
+++ b/src/components/Main/Teams/TeamList.tsx
@@ -37,8 +37,8 @@ export const TeamList = ({ teams, draggedMember }: TeamListProps) => {
 const NewTeamCard = ({ handleClick }: any) => {
   const classes = useStyles();
   return (
-    <Card className={classes.root}>
-      <CardContent className={classes.details}>
+    <Card className={classes.card}>
+      <CardContent className={classes.cardDetails}>
         <IconButton>
           <AddIcon />
         </IconButton>
@@ -46,22 +46,17 @@ const NewTeamCard = ({ handleClick }: any) => {
     </Card>
   );
 };
+
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
+  card: {
     display: 'flex',
     margin: '.5em',
     height: '20vh',
-    // backgroundColor: 'yellow',
   },
-  details: {
+  cardDetails: {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     width: '15vw',
-    // backgroundColor: 'red',
-  },
-  list: {
-    flexGrow: 10,
-    // backgroundColor: 'blue',
   },
 }));

--- a/src/components/shared/ConfirmationDialog.tsx
+++ b/src/components/shared/ConfirmationDialog.tsx
@@ -11,31 +11,64 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+
 export interface SimpleDialogProps {
-    title: string;
-    isOpen: boolean;
-    handleClick: (shouldDelete: boolean) => void;
+  title: string;
+  isOpen: boolean;
+  handleClick: (shouldDelete: boolean) => void;
 }
 
 export function ConfirmationDialog({ handleClick, isOpen, title }: SimpleDialogProps) {
-  
-    return (
-      <Dialog onBackdropClick={() => handleClick(!isOpen)} open={isOpen}>
-        <DialogTitle id='confirm-dialog'>{title}</DialogTitle>
-        <List>
-          <ListItem button onClick={() => handleClick(true)} key="yes-button">
-            <ListItemIcon style={{color: green[500] }}>
-              <CheckIcon/>
-            </ListItemIcon>
-            <ListItemText primary="YES"/>
-          </ListItem>
-          <ListItem button onClick={() => handleClick(false)} key="no-button">
-            <ListItemIcon style={{color: '#ba000d' }}>
-              <ClearIcon/>
-            </ListItemIcon>
-            <ListItemText primary="NO"/>
-          </ListItem>
-        </List>
-      </Dialog>
-    )
-  }
+  const classes = useStyles();
+  return (
+    <Dialog onBackdropClick={() => handleClick(!isOpen)} open={isOpen}>
+      <DialogTitle id="confirm-dialog">{title}</DialogTitle>
+      <List>
+        <ListItem
+          button
+          onClick={() => handleClick(true)}
+          key="yes-button"
+          className={classes.listItem}
+        >
+          <ListItemIcon style={{ color: green[500] }}>
+            <CheckIcon />
+          </ListItemIcon>
+          <ListItemText primary="YES" />
+        </ListItem>
+        <ListItem
+          button
+          onClick={() => handleClick(false)}
+          key="no-button"
+          className={classes.listItem}
+        >
+          <ListItemIcon style={{ color: '#ba000d' }}>
+            <ClearIcon />
+          </ListItemIcon>
+          <ListItemText primary="NO" />
+        </ListItem>
+      </List>
+    </Dialog>
+  );
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      '& [role="dialog"]': {
+        width: '40%',
+        maxWidth: '600px',
+        minWidth: '300px',
+      },
+    },
+    listItem: {
+      width: '50%',
+      margin: 'auto',
+      '& > *': {
+        display: 'flex',
+        flex: 1,
+        justifyContent: 'flex-start',
+      },
+    },
+  }),
+);

--- a/src/components/shared/FormDialog.tsx
+++ b/src/components/shared/FormDialog.tsx
@@ -69,9 +69,10 @@ export function FormDialog({ handleClose, isOpen, title }: AddUserProps) {
         clearPresets();
       }}
       open={isOpen}
+      className={classes.root}
     >
       <DialogTitle id="confirm-dialog">{title} </DialogTitle>
-      <form className={classes.root} noValidate autoComplete="off">
+      <form noValidate autoComplete="off" className={classes.form}>
         <FormField
           name={'firstname'}
           label={'First Name'}
@@ -112,6 +113,7 @@ export function FormDialog({ handleClose, isOpen, title }: AddUserProps) {
             }
           }}
           key="yes-button"
+          className={classes.listItem}
         >
           <ListItemIcon style={{ color: green[500] }}>
             <CheckIcon />
@@ -125,6 +127,7 @@ export function FormDialog({ handleClose, isOpen, title }: AddUserProps) {
             clearPresets();
           }}
           key="no-button"
+          className={classes.listItem}
         >
           <ListItemIcon style={{ color: '#ba000d' }}>
             <ClearIcon />
@@ -139,9 +142,23 @@ export function FormDialog({ handleClose, isOpen, title }: AddUserProps) {
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
+      '& [role="dialog"]': {
+        width: '300px',
+      },
+    },
+    form: {
       '& > *': {
-        margin: theme.spacing(1),
-        width: '25ch',
+        margin: '8px',
+        width: 'calc(100% - 8px * 2)',
+      },
+    },
+    listItem: {
+      width: '50%',
+      margin: 'auto',
+      '& > *': {
+        display: 'flex',
+        flex: 1,
+        justifyContent: 'flex-start',
       },
     },
   }),

--- a/src/shared/styles/theme.js
+++ b/src/shared/styles/theme.js
@@ -79,6 +79,7 @@ export const themeExtension = {
     backgroundColor: mainBackgroundColor,
     boxShadow: '#CCCCCC 0 2px 23px',
     transition: fastTransitionTime,
+    border: 'transparent 2px solid',
     hover: {
       border: `${interactiveColorBlue} 2px solid`,
       boxShadow: '#CCDBE0 0 2px 23px',


### PR DESCRIPTION
## team lists are now (dynamically) multi-line:
<img height="300" alt="Screen Shot 2020-11-10 at 20 49 57" src="https://user-images.githubusercontent.com/18131787/98757577-d5924200-239a-11eb-8ddb-062ee1a19af3.gif">

```css
/* thanks to: */
display: grid;
grid-template-columns: repeat(auto-fill, 20ch);
```

If you'd prefer, I remember it's possible to change the direction that the columns/rows fill (rows first or columns first). 

## team cards no longer "shift" when you hover over them:
<img height="300" alt="Screen Shot 2020-11-10 at 20 49 57" src="https://user-images.githubusercontent.com/18131787/98757564-cad7ad00-239a-11eb-806c-965fd67f8b4e.gif">

```css
/* just needed an invisible border with the same width as when it's hovered: */
border: transparent 2px solid; /* when NOT hovered */
border: <some-color> 2px solid; /* when hovered */
```

## 2 modals before: (note width relative to text and button alignment)
<img height="250" alt="Screen Shot 2020-11-10 at 20 55 18" src="https://user-images.githubusercontent.com/18131787/98757432-8a782f00-239a-11eb-8f7b-551e47fe4568.png"><img height="200" alt="Screen Shot 2020-11-10 at 20 54 57" src="https://user-images.githubusercontent.com/18131787/98757437-8c41f280-239a-11eb-9430-773dab4da982.png">

## 2 modals after: (note width relative to text and button alignment)
<img height="250" alt="Screen Shot 2020-11-10 at 20 49 57" src="https://user-images.githubusercontent.com/18131787/98757446-8ea44c80-239a-11eb-8c1d-febd7402aa47.png"><img height="200" alt="Screen Shot 2020-11-10 at 20 49 47" src="https://user-images.githubusercontent.com/18131787/98757449-906e1000-239a-11eb-9dc1-17680647a7b3.png">
